### PR TITLE
Cambios para soportar Flutter 3.13.6 y iOS 17 + Xcode 15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ Tipos de cambios
 
 ## [Unreleased]
 
+### Changed
+
+- Se actualizan dependecias de Flutter
+
 ## [2.11.9] - 2023-10-11Z
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 # Mi UTEM para Android e iOS
 Aplicación multiplataforma hecha por estudiantes de la [Universidad Tecnológica Metropolitana de Chile](https://www.utem.cl/) enfocada en adaptar la [plataforma académica Mi.UTEM](https://mi.utem.cl/) de la institución a dispositivos móviles.
 
-## Créditos
-Aplicación hecho por el Club de Desarrollo Experimental.
+## Requisitos técnicos
+- Flutter 3.13.6
 
-### Miembros del club
-* Sebastián Albornoz Medina ([@Ballena0](https://github.com/ballena0  "GitHub de Sebastián Albornoz Medina")) - Desarrollador
-* Juan Avendaño Nuñez ([@Javendanon](https://github.com/Javendanon  "GitHub de Juan Avendaño Nuñez")) - Desarrollador
-* Felipe Flores Vivanco ([@Spipe](https://github.com/spipe  "GitHub de Felipe Flores Vivanco")) - Desarrollador
-* Mariam V. Maldonado Marin ([@mariam6697](https://github.com/mariam6697  "GitHub de Mariam V. Maldonado Marin")) - Desarrolladora
-* Jorge Verdugo Chacón ([@mapacheverdugo](https://github.com/mapacheverdugo/  "GitHub de Jorge Verdugo Chacón")) - Desarrollador
-* Javiera Vergara Navarro ([@PollitoMayo](https://github.com/pollitomayo/  "GitHub de Javiera Vergara Navarro")) - Desarrolladora / Ilustradora
+## Créditos
+Este proyecto fue creado por el Club de Desarrollo Experimental (ExDev) de la Universidad Tecnológica Metropolitana y es mantenido por los propios estudiantes con el apoyo del equipo de SISEI. Mira los perfiles que han contribuido a este proyecto:
+
+<a href="https://github.com/exdevutem/mi-utem/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=exdevutem/mi-utem" />
+</a>

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,6 +38,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -16,9 +16,13 @@ Si incluyes nuevas dependencias, por favor, haz una lista de las necesarias.
 
 # Checklist:
 
-- [ ] He practicado una revisión de mi propio codigo.
-- [ ] He comentado mi codigo, sobretodo en las partes que pueden resultar dificiles de entender.
-- [ ] Mis cambios no generan nuevas alertas (Warnings).
+- [ ] He hecho una revisión de mi propio codigo.
+- [ ] Hice pruebas en un dispositivo Android real.
+- [ ] Hice pruebas en un dispositivo Android emulador.
+- [ ] Hice pruebas en un dispositivo iOS real.
+- [ ] Hice pruebas en un dispositivo iOS simulador.
+- [ ] Mis cambios no generan nuevos lint Problems.
+- [ ] Agregué mis cambios al CHANGELOG.md.
 - [ ] Este pull request contiene <1000 lineas de codigo (LOC).
 
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -83,6 +83,7 @@ platform :mobile do
     type = "release"
     skip_android = false
     skip_ios = false
+    skip_clean = false
     skip_match = false
     skip_cocoapods = false
     skip_git_push = false
@@ -99,6 +100,10 @@ platform :mobile do
 
     if options[:skip_ios]
       skip_ios = options[:skip_ios]
+    end
+
+    if options[:skip_clean]
+      skip_clean = options[:skip_clean]
     end
 
     if options[:skip_match]
@@ -132,7 +137,7 @@ platform :mobile do
         changelog: changelog,
         type: type,
         is_ci: is_ci,
-        skip_clean: false,
+        skip_clean: skip_clean,
       )
     end
 
@@ -142,7 +147,7 @@ platform :mobile do
         build_name: build_name,
         changelog: changelog,
         type: type,
-        skip_clean: !skip_android,
+        skip_clean: skip_clean || !skip_android,
         skip_match: skip_match,
         skip_cocoapods: skip_cocoapods,
         is_ci: is_ci,

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -599,6 +599,8 @@ PODS:
   - awesome_notifications (0.0.5):
     - Flutter
     - IosAwnCore (= 0.7.3)
+  - awesome_notifications_core (0.0.1):
+    - Flutter
   - awesome_notifications_fcm (0.7.3):
     - awesome_notifications
     - Firebase
@@ -655,7 +657,7 @@ PODS:
     - Firebase/RemoteConfig (= 10.7.0)
     - firebase_core
     - Flutter
-  - FirebaseABTesting (10.14.0):
+  - FirebaseABTesting (10.16.0):
     - FirebaseCore (~> 10.0)
   - FirebaseAnalytics (10.7.0):
     - FirebaseAnalytics/AdIdSupport (= 10.7.0)
@@ -679,7 +681,7 @@ PODS:
     - FirebaseCoreInternal (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - GoogleUtilities/Logger (~> 7.8)
-  - FirebaseCoreInternal (10.14.0):
+  - FirebaseCoreInternal (10.16.0):
     - "GoogleUtilities/NSData+zlib (~> 7.8)"
   - FirebaseFirestore (10.7.0):
     - abseil/algorithm (~> 1.20211102.0)
@@ -700,7 +702,7 @@ PODS:
     - FirebaseInstallations (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - FirebaseInstallations (10.14.0):
+  - FirebaseInstallations (10.16.0):
     - FirebaseCore (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - GoogleUtilities/UserDefaults (~> 7.8)
@@ -854,11 +856,13 @@ PODS:
   - permission_handler_apple (9.1.1):
     - Flutter
   - PromisesObjC (2.3.1)
-  - Sentry/HybridSDK (7.31.5)
+  - Sentry/HybridSDK (8.11.0):
+    - SentryPrivate (= 8.11.0)
   - sentry_flutter (0.0.1):
     - Flutter
     - FlutterMacOS
-    - Sentry/HybridSDK (= 7.31.5)
+    - Sentry/HybridSDK (= 8.11.0)
+  - SentryPrivate (8.11.0)
   - share_plus (0.0.1):
     - Flutter
   - shared_preferences_foundation (0.0.1):
@@ -869,12 +873,13 @@ PODS:
     - FMDB (>= 2.7.5)
   - url_launcher_ios (0.0.1):
     - Flutter
-  - UXCam (3.6.5)
+  - UXCam (3.6.6)
   - video_player_avfoundation (0.0.1):
     - Flutter
 
 DEPENDENCIES:
   - awesome_notifications (from `.symlinks/plugins/awesome_notifications/ios`)
+  - awesome_notifications_core (from `.symlinks/plugins/awesome_notifications_core/ios`)
   - awesome_notifications_fcm (from `.symlinks/plugins/awesome_notifications_fcm/ios`)
   - background_fetch (from `.symlinks/plugins/background_fetch/ios`)
   - cloud_firestore (from `.symlinks/plugins/cloud_firestore/ios`)
@@ -890,11 +895,11 @@ DEPENDENCIES:
   - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
   - in_app_review (from `.symlinks/plugins/in_app_review/ios`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
-  - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/ios`)
+  - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
   - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
   - sentry_flutter (from `.symlinks/plugins/sentry_flutter/ios`)
   - share_plus (from `.symlinks/plugins/share_plus/ios`)
-  - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/ios`)
+  - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
   - sqflite (from `.symlinks/plugins/sqflite/ios`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
   - video_player_avfoundation (from `.symlinks/plugins/video_player_avfoundation/ios`)
@@ -926,11 +931,14 @@ SPEC REPOS:
     - nanopb
     - PromisesObjC
     - Sentry
+    - SentryPrivate
     - UXCam
 
 EXTERNAL SOURCES:
   awesome_notifications:
     :path: ".symlinks/plugins/awesome_notifications/ios"
+  awesome_notifications_core:
+    :path: ".symlinks/plugins/awesome_notifications_core/ios"
   awesome_notifications_fcm:
     :path: ".symlinks/plugins/awesome_notifications_fcm/ios"
   background_fetch:
@@ -962,7 +970,7 @@ EXTERNAL SOURCES:
   package_info_plus:
     :path: ".symlinks/plugins/package_info_plus/ios"
   path_provider_foundation:
-    :path: ".symlinks/plugins/path_provider_foundation/ios"
+    :path: ".symlinks/plugins/path_provider_foundation/darwin"
   permission_handler_apple:
     :path: ".symlinks/plugins/permission_handler_apple/ios"
   sentry_flutter:
@@ -970,7 +978,7 @@ EXTERNAL SOURCES:
   share_plus:
     :path: ".symlinks/plugins/share_plus/ios"
   shared_preferences_foundation:
-    :path: ".symlinks/plugins/shared_preferences_foundation/ios"
+    :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
   sqflite:
     :path: ".symlinks/plugins/sqflite/ios"
   url_launcher_ios:
@@ -981,6 +989,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   abseil: ebe5b5529fb05d93a8bdb7951607be08b7fa71bc
   awesome_notifications: d63d9a25f126860f9a600850d99772237895b3ba
+  awesome_notifications_core: d02eed89738fa362d56cbd372850e9adcd2c6bef
   awesome_notifications_fcm: 7e2d7ab4ca1826fe3a9a5ca96771ace73e05db48
   background_fetch: 896944864b038d2837fc750d470e9841e1e6a363
   BoringSSL-GRPC: 3175b25143e648463a56daeaaa499c6cb86dad33
@@ -990,13 +999,13 @@ SPEC CHECKSUMS:
   firebase_core: dee76ded6c693fdb38b8ea39aef7129e32e587a3
   firebase_in_app_messaging: 2b36a1746f4fefbd6f578a2f6659358a0d3f2c94
   firebase_remote_config: e5f1ed5b29191424280b7b249228f0ed64bc90ee
-  FirebaseABTesting: e1535073fac4ff55c7537a6e041155c72d9e6906
+  FirebaseABTesting: 03f0a8b88cf618350527f2c6a2234e29b9c65064
   FirebaseAnalytics: f8133442ee6f8512e28ff19e62ce15398bfaeace
   FirebaseCore: e317665b9d744727a97e623edbbed009320afdd7
-  FirebaseCoreInternal: d558159ee6cc4b823c2296ecc193de9f6d9a5bb3
+  FirebaseCoreInternal: 26233f705cc4531236818a07ac84d20c333e505a
   FirebaseFirestore: 3963a6edd1c84b4748dab3e2c62624a29d03eca1
   FirebaseInAppMessaging: d04732fe9c37c3d026d66435abba60120087a7f5
-  FirebaseInstallations: f672b1eda64e6381c21d424a2f680a943fd83f3b
+  FirebaseInstallations: b822f91a61f7d1ba763e5ccc9d4f2e6f2ed3b3ee
   FirebaseMessaging: ac9062bcc35ed56e15a0241d8fd317022499baf8
   FirebaseRemoteConfig: d5de62211e2eaa2152d8ee85a23c301b70887a74
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
@@ -1017,19 +1026,20 @@ SPEC CHECKSUMS:
   leveldb-library: f03246171cce0484482ec291f88b6d563699ee06
   Libuv-gRPC: 55e51798e14ef436ad9bc45d12d43b77b49df378
   nanopb: b552cce312b6c8484180ef47159bc0f65a1f0431
-  package_info_plus: 6c92f08e1f853dc01228d6f553146438dafcd14e
+  package_info_plus: 115f4ad11e0698c8c1c5d8a689390df880f47e85
   path_provider_foundation: 29f094ae23ebbca9d3d0cec13889cd9060c0e943
   permission_handler_apple: e76247795d700c14ea09e3a2d8855d41ee80a2e6
   PromisesObjC: c50d2056b5253dadbd6c2bea79b0674bd5a52fa4
-  Sentry: 4c9babff9034785067c896fd580b1f7de44da020
-  sentry_flutter: 1346a880b24c0240807b53b10cf50ddad40f504e
-  share_plus: 056a1e8ac890df3e33cb503afffaf1e9b4fbae68
+  Sentry: 39d57e691e311bdb73bc1ab5bbebbd6bc890050d
+  sentry_flutter: b2feefdad5b0f06602347172bc7257e8e9da5562
+  SentryPrivate: 48712023cdfd523735c2edb6b06bedf26c4730a3
+  share_plus: c3fef564749587fc939ef86ffb283ceac0baf9f5
   shared_preferences_foundation: 5b919d13b803cadd15ed2dc053125c68730e5126
   sqflite: 31f7eba61e3074736dff8807a9b41581e4f7f15a
   url_launcher_ios: 08a3dfac5fb39e8759aeb0abbd5d9480f30fc8b4
-  UXCam: d2f9782c4e99ecf10f7aae15edd244e2f6346154
+  UXCam: 7f200dd8f0829ae92a2ef82cadbb35dadff6108d
   video_player_avfoundation: 81e49bb3d9fb63dccf9fa0f6d877dc3ddbeac126
 
 PODFILE CHECKSUM: 816280d49dfc997733647f095bf1e4c52c291937
 
-COCOAPODS: 1.12.1
+COCOAPODS: 1.13.0

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -8,13 +8,13 @@
 
 /* Begin PBXBuildFile section */
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
-		30DAE1CFC81DDE043C47EFB7 /* Pods_MiUtemNotificationServiceExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 175FD8BE5FEC6733F528FF6A /* Pods_MiUtemNotificationServiceExtension.framework */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
-		4B47F7BDE8FF84101E5DC4A7 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 243E7D668CFCB834EA06F2F9 /* Pods_Runner.framework */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
+		8F4ED3CFA3A6AA57DAA4905A /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6121D4E2A474C9DE828CDCAE /* Pods_Runner.framework */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
+		CD503047F9D302C06B5A0368 /* Pods_MiUtemNotificationServiceExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CD7FFD10A37572B5E2396877 /* Pods_MiUtemNotificationServiceExtension.framework */; };
 		EBBC93162A9CF30F00452092 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = EBBC93152A9CF30F00452092 /* GoogleService-Info.plist */; };
 		EBCDF3152A08916400C04BA3 /* prod.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = EBCDF3142A08916400C04BA3 /* prod.xcconfig */; };
 		EBCDF3162A08916400C04BA3 /* prod.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = EBCDF3142A08916400C04BA3 /* prod.xcconfig */; };
@@ -59,20 +59,21 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		0E66CE5E3A60A9B1934B64CA /* Pods-Runner.profile-dev.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile-dev.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile-dev.xcconfig"; sourceTree = "<group>"; };
+		028D1D60BF59B575889466D8 /* Pods-Runner.profile-dev.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile-dev.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile-dev.xcconfig"; sourceTree = "<group>"; };
+		0D18ECB963B9AC9E555F6D58 /* Pods-MiUtemNotificationServiceExtension.profile-prod.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MiUtemNotificationServiceExtension.profile-prod.xcconfig"; path = "Target Support Files/Pods-MiUtemNotificationServiceExtension/Pods-MiUtemNotificationServiceExtension.profile-prod.xcconfig"; sourceTree = "<group>"; };
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
-		175FD8BE5FEC6733F528FF6A /* Pods_MiUtemNotificationServiceExtension.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MiUtemNotificationServiceExtension.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		19EE483FBE4F0DA023507A8A /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
-		1DABD6A006BB1390BCF23593 /* Pods-Runner.debug-prod.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug-prod.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug-prod.xcconfig"; sourceTree = "<group>"; };
-		1E98DE4BD311960EB4037F29 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
-		243E7D668CFCB834EA06F2F9 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		1D195389E35AFDBBC19F556A /* Pods-MiUtemNotificationServiceExtension.profile-dev.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MiUtemNotificationServiceExtension.profile-dev.xcconfig"; path = "Target Support Files/Pods-MiUtemNotificationServiceExtension/Pods-MiUtemNotificationServiceExtension.profile-dev.xcconfig"; sourceTree = "<group>"; };
+		2A8E76026D6C8EDF63A50739 /* Pods-MiUtemNotificationServiceExtension.debug-prod.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MiUtemNotificationServiceExtension.debug-prod.xcconfig"; path = "Target Support Files/Pods-MiUtemNotificationServiceExtension/Pods-MiUtemNotificationServiceExtension.debug-prod.xcconfig"; sourceTree = "<group>"; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
-		4966531EF6EB9FC094381CC5 /* Pods-MiUtemNotificationServiceExtension.debug-dev.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MiUtemNotificationServiceExtension.debug-dev.xcconfig"; path = "Target Support Files/Pods-MiUtemNotificationServiceExtension/Pods-MiUtemNotificationServiceExtension.debug-dev.xcconfig"; sourceTree = "<group>"; };
-		6A2BEBBB25934DE09542A657 /* Pods-MiUtemNotificationServiceExtension.debug-prod.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MiUtemNotificationServiceExtension.debug-prod.xcconfig"; path = "Target Support Files/Pods-MiUtemNotificationServiceExtension/Pods-MiUtemNotificationServiceExtension.debug-prod.xcconfig"; sourceTree = "<group>"; };
+		5D4267C91BD4F6CA29666EAE /* Pods-Runner.profile-prod.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile-prod.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile-prod.xcconfig"; sourceTree = "<group>"; };
+		6121D4E2A474C9DE828CDCAE /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		67917C6A3CFC662D52BE1420 /* Pods-Runner.debug-prod.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug-prod.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug-prod.xcconfig"; sourceTree = "<group>"; };
+		6DE503BB399A91B6C5520D76 /* Pods-Runner.release-dev.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release-dev.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release-dev.xcconfig"; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
+		7FE2002C76C7F77E5A50737A /* Pods-MiUtemNotificationServiceExtension.debug-dev.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MiUtemNotificationServiceExtension.debug-dev.xcconfig"; path = "Target Support Files/Pods-MiUtemNotificationServiceExtension/Pods-MiUtemNotificationServiceExtension.debug-dev.xcconfig"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
 		97C146EE1CF9000F007C117D /* Runner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Runner.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -80,18 +81,11 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		9CBD779D41F276A7AC2B572E /* Pods-MiUtemNotificationServiceExtension.release-dev.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MiUtemNotificationServiceExtension.release-dev.xcconfig"; path = "Target Support Files/Pods-MiUtemNotificationServiceExtension/Pods-MiUtemNotificationServiceExtension.release-dev.xcconfig"; sourceTree = "<group>"; };
-		A8FD661028BC76BA36783754 /* Pods-Runner.release-dev.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release-dev.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release-dev.xcconfig"; sourceTree = "<group>"; };
-		A9DBD6E19A9BF248843741C2 /* Pods-Runner.release-prod.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release-prod.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release-prod.xcconfig"; sourceTree = "<group>"; };
-		BC4589FD8E823EE03AE597C3 /* Pods-MiUtemNotificationServiceExtension.profile-prod.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MiUtemNotificationServiceExtension.profile-prod.xcconfig"; path = "Target Support Files/Pods-MiUtemNotificationServiceExtension/Pods-MiUtemNotificationServiceExtension.profile-prod.xcconfig"; sourceTree = "<group>"; };
-		C9B2E091E8F8621D6AB5E571 /* Pods-Runner.debug-dev.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug-dev.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug-dev.xcconfig"; sourceTree = "<group>"; };
-		D0E6334983448057168822B6 /* Pods-MiUtemNotificationServiceExtension.profile-dev.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MiUtemNotificationServiceExtension.profile-dev.xcconfig"; path = "Target Support Files/Pods-MiUtemNotificationServiceExtension/Pods-MiUtemNotificationServiceExtension.profile-dev.xcconfig"; sourceTree = "<group>"; };
-		D344C06D3AF70CF3F876E06C /* Pods-MiUtemNotificationServiceExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MiUtemNotificationServiceExtension.release.xcconfig"; path = "Target Support Files/Pods-MiUtemNotificationServiceExtension/Pods-MiUtemNotificationServiceExtension.release.xcconfig"; sourceTree = "<group>"; };
-		DA0B179EA806614E04AA7C25 /* Pods-MiUtemNotificationServiceExtension.release-prod.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MiUtemNotificationServiceExtension.release-prod.xcconfig"; path = "Target Support Files/Pods-MiUtemNotificationServiceExtension/Pods-MiUtemNotificationServiceExtension.release-prod.xcconfig"; sourceTree = "<group>"; };
-		DAD427C338F11F0C1F044F0C /* Pods-MiUtemNotificationServiceExtension.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MiUtemNotificationServiceExtension.profile.xcconfig"; path = "Target Support Files/Pods-MiUtemNotificationServiceExtension/Pods-MiUtemNotificationServiceExtension.profile.xcconfig"; sourceTree = "<group>"; };
-		E3DF90F3A21807C39C03D30F /* Pods-Runner.profile-prod.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile-prod.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile-prod.xcconfig"; sourceTree = "<group>"; };
-		E70F7055917B6FFFAE576207 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
-		E89F309C88BB79A4A8742037 /* Pods-MiUtemNotificationServiceExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MiUtemNotificationServiceExtension.debug.xcconfig"; path = "Target Support Files/Pods-MiUtemNotificationServiceExtension/Pods-MiUtemNotificationServiceExtension.debug.xcconfig"; sourceTree = "<group>"; };
+		A3FA1AB011DC323121CB4846 /* Pods-Runner.debug-dev.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug-dev.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug-dev.xcconfig"; sourceTree = "<group>"; };
+		C18F971B0C4AE83409EF3EE9 /* Pods-MiUtemNotificationServiceExtension.release-dev.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MiUtemNotificationServiceExtension.release-dev.xcconfig"; path = "Target Support Files/Pods-MiUtemNotificationServiceExtension/Pods-MiUtemNotificationServiceExtension.release-dev.xcconfig"; sourceTree = "<group>"; };
+		CD7FFD10A37572B5E2396877 /* Pods_MiUtemNotificationServiceExtension.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MiUtemNotificationServiceExtension.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D64F29F37589757D056742C4 /* Pods-Runner.release-prod.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release-prod.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release-prod.xcconfig"; sourceTree = "<group>"; };
+		E9D8206B317F8C4150388A29 /* Pods-MiUtemNotificationServiceExtension.release-prod.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MiUtemNotificationServiceExtension.release-prod.xcconfig"; path = "Target Support Files/Pods-MiUtemNotificationServiceExtension/Pods-MiUtemNotificationServiceExtension.release-prod.xcconfig"; sourceTree = "<group>"; };
 		EBBC93152A9CF30F00452092 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		EBCDF3142A08916400C04BA3 /* prod.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = prod.xcconfig; sourceTree = "<group>"; };
 		EBCDF3172A0891B800C04BA3 /* dev.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = dev.xcconfig; sourceTree = "<group>"; };
@@ -106,7 +100,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4B47F7BDE8FF84101E5DC4A7 /* Pods_Runner.framework in Frameworks */,
+				8F4ED3CFA3A6AA57DAA4905A /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -114,34 +108,37 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				30DAE1CFC81DDE043C47EFB7 /* Pods_MiUtemNotificationServiceExtension.framework in Frameworks */,
+				CD503047F9D302C06B5A0368 /* Pods_MiUtemNotificationServiceExtension.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		5943468C977B0D2375AA5EA6 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				CD7FFD10A37572B5E2396877 /* Pods_MiUtemNotificationServiceExtension.framework */,
+				6121D4E2A474C9DE828CDCAE /* Pods_Runner.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		5BE064586DEE9A90F78F289D /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				E70F7055917B6FFFAE576207 /* Pods-Runner.debug.xcconfig */,
-				19EE483FBE4F0DA023507A8A /* Pods-Runner.release.xcconfig */,
-				1E98DE4BD311960EB4037F29 /* Pods-Runner.profile.xcconfig */,
-				E89F309C88BB79A4A8742037 /* Pods-MiUtemNotificationServiceExtension.debug.xcconfig */,
-				D344C06D3AF70CF3F876E06C /* Pods-MiUtemNotificationServiceExtension.release.xcconfig */,
-				DAD427C338F11F0C1F044F0C /* Pods-MiUtemNotificationServiceExtension.profile.xcconfig */,
-				4966531EF6EB9FC094381CC5 /* Pods-MiUtemNotificationServiceExtension.debug-dev.xcconfig */,
-				9CBD779D41F276A7AC2B572E /* Pods-MiUtemNotificationServiceExtension.release-dev.xcconfig */,
-				D0E6334983448057168822B6 /* Pods-MiUtemNotificationServiceExtension.profile-dev.xcconfig */,
-				C9B2E091E8F8621D6AB5E571 /* Pods-Runner.debug-dev.xcconfig */,
-				A8FD661028BC76BA36783754 /* Pods-Runner.release-dev.xcconfig */,
-				0E66CE5E3A60A9B1934B64CA /* Pods-Runner.profile-dev.xcconfig */,
-				6A2BEBBB25934DE09542A657 /* Pods-MiUtemNotificationServiceExtension.debug-prod.xcconfig */,
-				DA0B179EA806614E04AA7C25 /* Pods-MiUtemNotificationServiceExtension.release-prod.xcconfig */,
-				BC4589FD8E823EE03AE597C3 /* Pods-MiUtemNotificationServiceExtension.profile-prod.xcconfig */,
-				1DABD6A006BB1390BCF23593 /* Pods-Runner.debug-prod.xcconfig */,
-				A9DBD6E19A9BF248843741C2 /* Pods-Runner.release-prod.xcconfig */,
-				E3DF90F3A21807C39C03D30F /* Pods-Runner.profile-prod.xcconfig */,
+				2A8E76026D6C8EDF63A50739 /* Pods-MiUtemNotificationServiceExtension.debug-prod.xcconfig */,
+				7FE2002C76C7F77E5A50737A /* Pods-MiUtemNotificationServiceExtension.debug-dev.xcconfig */,
+				E9D8206B317F8C4150388A29 /* Pods-MiUtemNotificationServiceExtension.release-prod.xcconfig */,
+				C18F971B0C4AE83409EF3EE9 /* Pods-MiUtemNotificationServiceExtension.release-dev.xcconfig */,
+				0D18ECB963B9AC9E555F6D58 /* Pods-MiUtemNotificationServiceExtension.profile-prod.xcconfig */,
+				1D195389E35AFDBBC19F556A /* Pods-MiUtemNotificationServiceExtension.profile-dev.xcconfig */,
+				67917C6A3CFC662D52BE1420 /* Pods-Runner.debug-prod.xcconfig */,
+				A3FA1AB011DC323121CB4846 /* Pods-Runner.debug-dev.xcconfig */,
+				D64F29F37589757D056742C4 /* Pods-Runner.release-prod.xcconfig */,
+				6DE503BB399A91B6C5520D76 /* Pods-Runner.release-dev.xcconfig */,
+				5D4267C91BD4F6CA29666EAE /* Pods-Runner.profile-prod.xcconfig */,
+				028D1D60BF59B575889466D8 /* Pods-Runner.profile-dev.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -167,7 +164,7 @@
 				EBE5B6BC29D4D890005924AB /* MiUtemNotificationServiceExtension */,
 				97C146EF1CF9000F007C117D /* Products */,
 				5BE064586DEE9A90F78F289D /* Pods */,
-				F6A1FF0D1A697AB576081748 /* Frameworks */,
+				5943468C977B0D2375AA5EA6 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -206,15 +203,6 @@
 			path = MiUtemNotificationServiceExtension;
 			sourceTree = "<group>";
 		};
-		F6A1FF0D1A697AB576081748 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				243E7D668CFCB834EA06F2F9 /* Pods_Runner.framework */,
-				175FD8BE5FEC6733F528FF6A /* Pods_MiUtemNotificationServiceExtension.framework */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -222,16 +210,16 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
-				94E083E75031E6E772DBDA7C /* [CP] Check Pods Manifest.lock */,
+				4CFEEF06D81C25B5F5382E38 /* [CP] Check Pods Manifest.lock */,
 				EB04E4B02A08BA2D00698618 /* Firebase */,
 				9740EEB61CF901F6004384FC /* Run Script */,
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
+				EBE5B6C729D4D890005924AB /* Embed Foundation Extensions */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
-				09DFE2173D67B99B024BDA8C /* [CP] Embed Pods Frameworks */,
-				EBE5B6C729D4D890005924AB /* Embed Foundation Extensions */,
+				D373ECD8927B88A41A34AE2E /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -247,7 +235,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = EBE5B6C329D4D890005924AB /* Build configuration list for PBXNativeTarget "MiUtemNotificationServiceExtension" */;
 			buildPhases = (
-				5CA1814B24B462F60978F7B3 /* [CP] Check Pods Manifest.lock */,
+				A4370C68AA35EFC7FD3B8BDC /* [CP] Check Pods Manifest.lock */,
 				EBE5B6B729D4D890005924AB /* Sources */,
 				EBE5B6B829D4D890005924AB /* Frameworks */,
 				EBE5B6B929D4D890005924AB /* Resources */,
@@ -268,7 +256,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1420;
-				LastUpgradeCheck = 1300;
+				LastUpgradeCheck = 1430;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {
@@ -326,23 +314,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		09DFE2173D67B99B024BDA8C /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -350,6 +321,7 @@
 			files = (
 			);
 			inputPaths = (
+				"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}",
 			);
 			name = "Thin Binary";
 			outputPaths = (
@@ -358,29 +330,7 @@
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
 		};
-		5CA1814B24B462F60978F7B3 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-MiUtemNotificationServiceExtension-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		94E083E75031E6E772DBDA7C /* [CP] Check Pods Manifest.lock */ = {
+		4CFEEF06D81C25B5F5382E38 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -416,6 +366,45 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build\n";
+		};
+		A4370C68AA35EFC7FD3B8BDC /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-MiUtemNotificationServiceExtension-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		D373ECD8927B88A41A34AE2E /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
 		};
 		EB04E4B02A08BA2D00698618 /* Firebase */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -562,6 +551,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = cl.utem.miutem;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -703,6 +693,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = cl.utem.miutem;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -739,6 +730,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore cl.utem.miutem";
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -827,6 +819,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = cl.utem.miutem.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -836,7 +829,7 @@
 		};
 		EBCDF31C2A08921600C04BA3 /* Debug-dev */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4966531EF6EB9FC094381CC5 /* Pods-MiUtemNotificationServiceExtension.debug-dev.xcconfig */;
+			baseConfigurationReference = 7FE2002C76C7F77E5A50737A /* Pods-MiUtemNotificationServiceExtension.debug-dev.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				BUILD_LIBRARY_FOR_DISTRIBUTION = NO;
@@ -957,6 +950,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore cl.utem.miutem";
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -965,7 +959,7 @@
 		};
 		EBCDF31F2A08921C00C04BA3 /* Release-dev */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 9CBD779D41F276A7AC2B572E /* Pods-MiUtemNotificationServiceExtension.release-dev.xcconfig */;
+			baseConfigurationReference = C18F971B0C4AE83409EF3EE9 /* Pods-MiUtemNotificationServiceExtension.release-dev.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				BUILD_LIBRARY_FOR_DISTRIBUTION = NO;
@@ -1082,6 +1076,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = cl.utem.miutem.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -1090,7 +1085,7 @@
 		};
 		EBCDF3222A08922100C04BA3 /* Profile-dev */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = D0E6334983448057168822B6 /* Pods-MiUtemNotificationServiceExtension.profile-dev.xcconfig */;
+			baseConfigurationReference = 1D195389E35AFDBBC19F556A /* Pods-MiUtemNotificationServiceExtension.profile-dev.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				BUILD_LIBRARY_FOR_DISTRIBUTION = NO;
@@ -1128,7 +1123,7 @@
 		};
 		EBE5B6C429D4D890005924AB /* Debug-prod */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6A2BEBBB25934DE09542A657 /* Pods-MiUtemNotificationServiceExtension.debug-prod.xcconfig */;
+			baseConfigurationReference = 2A8E76026D6C8EDF63A50739 /* Pods-MiUtemNotificationServiceExtension.debug-prod.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				BUILD_LIBRARY_FOR_DISTRIBUTION = NO;
@@ -1169,7 +1164,7 @@
 		};
 		EBE5B6C529D4D890005924AB /* Release-prod */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = DA0B179EA806614E04AA7C25 /* Pods-MiUtemNotificationServiceExtension.release-prod.xcconfig */;
+			baseConfigurationReference = E9D8206B317F8C4150388A29 /* Pods-MiUtemNotificationServiceExtension.release-prod.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				BUILD_LIBRARY_FOR_DISTRIBUTION = NO;
@@ -1211,7 +1206,7 @@
 		};
 		EBE5B6C629D4D890005924AB /* Profile-prod */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = BC4589FD8E823EE03AE597C3 /* Pods-MiUtemNotificationServiceExtension.profile-prod.xcconfig */;
+			baseConfigurationReference = 0D18ECB963B9AC9E555F6D58 /* Pods-MiUtemNotificationServiceExtension.profile-prod.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				BUILD_LIBRARY_FOR_DISTRIBUTION = NO;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -45,10 +45,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.0"
+    version: "2.11.0"
   awesome_notifications:
     dependency: "direct main"
     description:
@@ -57,6 +57,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.4+1"
+  awesome_notifications_core:
+    dependency: "direct main"
+    description:
+      name: awesome_notifications_core
+      sha256: "0d67f3539aac87f9052b9eb204bdfbd00893a9d83b5975151098265428332bea"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.1"
   awesome_notifications_fcm:
     dependency: "direct main"
     description:
@@ -165,10 +173,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   charts_common:
     dependency: transitive
     description:
@@ -254,10 +262,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.17.2"
   convert:
     dependency: transitive
     description:
@@ -350,18 +358,18 @@ packages:
     dependency: "direct main"
     description:
       name: extended_image
-      sha256: a6b738d9b8d5513be72c545cc3e9c5c451fbee77c8db3cbec7c32ae85b82fb93
+      sha256: b4d72a27851751cfadaf048936d42939db7cd66c08fdcfe651eeaa1179714ee6
       url: "https://pub.dev"
     source: hosted
-    version: "6.4.1"
+    version: "8.1.1"
   extended_image_library:
     dependency: transitive
     description:
       name: extended_image_library
-      sha256: "550743b43ab093aed35ef234500fcc7a304cbac1eca47b0cc991e07e88750758"
+      sha256: "8bf87c0b14dcb59200c923a9a3952304e4732a0901e40811428834ef39018ee1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.2"
+    version: "3.6.0"
   fake_async:
     dependency: transitive
     description:
@@ -774,18 +782,18 @@ packages:
     dependency: transitive
     description:
       name: http
-      sha256: "5895291c13fa8a3bd82e76d5627f69e0d85ca6a30dcac95c4ea19a5d555879c2"
+      sha256: "759d1a329847dd0f39226c688d3e06a6b8679668e350e2891a6474f8b4bb8525"
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.6"
+    version: "1.1.0"
   http_client_helper:
     dependency: transitive
     description:
       name: http_client_helper
-      sha256: "14c6e756644339f561321dab021215475ba4779aa962466f59ccb3ecf66b36c3"
+      sha256: "8a9127650734da86b5c73760de2b404494c968a3fd55602045ffec789dac3cb1"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.4"
+    version: "3.0.0"
   http_parser:
     dependency: transitive
     description:
@@ -926,10 +934,10 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.5"
+    version: "0.6.7"
   json_annotation:
     dependency: "direct overridden"
     description:
@@ -982,18 +990,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.13"
+    version: "0.12.16"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.5.0"
   mdi:
     dependency: "direct main"
     description:
@@ -1006,10 +1014,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.9.1"
   mime:
     dependency: transitive
     description:
@@ -1038,10 +1046,10 @@ packages:
     dependency: "direct main"
     description:
       name: package_info_plus
-      sha256: "10259b111176fba5c505b102e3a5b022b51dd97e30522e906d6922c745584745"
+      sha256: "7e76fad405b3e4016cd39d08f455a4eb5199723cf594cd1b8916d47140d93017"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.2"
+    version: "4.2.0"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -1054,10 +1062,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.3"
   path_drawing:
     dependency: transitive
     description:
@@ -1278,42 +1286,42 @@ packages:
     dependency: "direct main"
     description:
       name: screenshot
-      sha256: "30bb9fade6eb2578a1fc2e84f6b184141fc86883cda10988d4500ff00eb728e2"
+      sha256: "455284ff1f5b911d94a43c25e1385485cf6b4f288293eba68f15dad711c7b81c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "2.1.0"
   sentry:
     dependency: transitive
     description:
       name: sentry
-      sha256: a1529c545fcbc899e5dcc7c94ff1c6ad0c334dfc99a3cda366b1da98af7c5678
+      sha256: "830667eadc0398fea3a3424ed1b74568e2db603a42758d0922e2f2974ce55a60"
       url: "https://pub.dev"
     source: hosted
-    version: "6.22.0"
+    version: "7.10.1"
   sentry_flutter:
     dependency: "direct main"
     description:
       name: sentry_flutter
-      sha256: cab07e99a8f27af94f399cabceaff6968011660505b30a0e2286728a81bc476c
+      sha256: "6730f41b304c6fb0fa590dacccaf73ba11082fc64b274cfe8a79776f2b95309c"
       url: "https://pub.dev"
     source: hosted
-    version: "6.22.0"
+    version: "7.10.1"
   share_plus:
     dependency: "direct main"
     description:
       name: share_plus
-      sha256: b1f15232d41e9701ab2f04181f21610c36c83a12ae426b79b4bd011c567934b1
+      sha256: f74fc3f1cbd99f39760182e176802f693fa0ec9625c045561cfad54681ea93dd
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.4"
+    version: "7.2.1"
   share_plus_platform_interface:
     dependency: transitive
     description:
       name: share_plus_platform_interface
-      sha256: "357412af4178d8e11d14f41723f80f12caea54cf0d5cd29af9dcdab85d58aea7"
+      sha256: df08bc3a07d01f5ea47b45d03ffcba1fa9cd5370fb44b3f38c70e42cced0f956
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.0"
+    version: "3.3.1"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -1395,10 +1403,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   sqflite:
     dependency: transitive
     description:
@@ -1459,10 +1467,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
+      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.16"
+    version: "0.6.0"
   tint:
     dependency: transitive
     description:
@@ -1615,14 +1623,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4-beta"
   win32:
     dependency: transitive
     description:
       name: win32
-      sha256: a6f0236dbda0f63aa9a25ad1ff9a9d8a4eaaa5012da0dc59d21afdb1dc361ca4
+      sha256: f2add6fa510d3ae152903412227bda57d0d5a8da61d2c39c1fb022c9429a41c0
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.4"
+    version: "5.0.6"
   xdg_directories:
     dependency: transitive
     description:
@@ -1648,5 +1664,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=2.19.0 <3.0.0"
-  flutter: ">=3.7.0"
+  dart: ">=3.1.0-185.0.dev <4.0.0"
+  flutter: ">=3.13.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,8 +9,9 @@ environment:
   sdk: ">=2.14.4 <3.0.0"
 
 dependencies:
-  awesome_notifications: ^0.7.4+1
-  awesome_notifications_fcm: ^0.7.4+1
+  awesome_notifications_core: ^0.8.1
+  awesome_notifications: any
+  awesome_notifications_fcm: any
   badges: ^2.0.2
   barcode_widget: ^2.0.3
   barcode_image: ^2.0.2
@@ -28,7 +29,7 @@ dependencies:
   dio_cache_interceptor: ^3.2.6
   dio_cache_interceptor_hive_store: ^3.1.1
   dotted_border: ^2.0.0+2
-  extended_image: ^6.0.2+1
+  extended_image: ^8.1.1
   firebase_core: 2.11.0
   firebase_analytics: 10.2.1
   firebase_in_app_messaging: ^0.7.0+10
@@ -54,16 +55,16 @@ dependencies:
   in_app_review: ^2.0.3
   logger: ^1.3.0
   mdi: ^5.0.0-nullsafety.0
-  package_info_plus: ^3.0.2
+  package_info_plus: ^4.2.0
   path_provider: ^2.0.2
   permission_handler: ^10.2.0
   photo_view: ^0.14.0
   qr_flutter: ^4.0.0
   recase: ^4.0.0
   responsive_framework: ^0.2.0
-  screenshot: ^1.2.3
-  sentry_flutter: ^6.18.2
-  share_plus: ^6.3.0
+  screenshot: ^2.1.0
+  sentry_flutter: ^7.10.1
+  share_plus: ^7.2.1
   simple_gesture_detector: ^0.2.0
   url_launcher: ^6.1.7
   video_player: ^2.6.1


### PR DESCRIPTION
# Descripción

Ahora la versión oficial de Flutter para correr el proyecto será Flutter 3.13.6 para poder soportar buildear la app en iOS 17 + Xcode 15

- Se actualizaron varias librerías para soportar Flutter 3.13.6
- Se actualizó el README para agregar la versión de Flutter y las caras de los contributors
- Se corrigió un temita que había con el `skip_clean` en el Fastlane de iOS


## Tipo de cambio

- [ ] Corrección de error.
- [ ] Nueva funcionalidad .
- [x] Breaking change (cambio que puede romper la aplicación).
- [x] Documentación.
- [ ] Mejora de codigo existente (performance y/o estilo del codigo y/o otra mejora)


# Checklist:

- [x] He practicado una revisión de mi propio codigo.
- [ ] He comentado mi codigo, sobretodo en las partes que pueden resultar dificiles de entender.
- [ ] Mis cambios no generan nuevas alertas (Warnings).
- [ ] Este pull request contiene <1000 lineas de codigo (LOC).

